### PR TITLE
short fixes for cut, crush, bandq

### DIFF
--- a/classes/DirtEvent.sc
+++ b/classes/DirtEvent.sc
@@ -179,6 +179,7 @@ DirtEvent {
 
 		~amp = pow(~gain, 4) * dirtBus.amp;
 		~channel !? { ~pan = ~pan + (~channel / ~numChannels) };
+		if (~cut.notNil) {~cutgroup = ~cut};
 
 		server.makeBundle(latency, { // use this to build a bundle
 

--- a/synths/core-modules.scd
+++ b/synths/core-modules.scd
@@ -107,12 +107,12 @@ they respond to the existence of a value for one of the tidal parameters
 	{ |dirtEvent|
 		dirtEvent.sendSynth("dirt_bpf" ++ ~numChannels,
 			[
-				bandqf: ~bandqf,
+				bandqf: ~bandf,
 				bandq: ~bandq,
 				out: ~out
 		])
 
-}, { ~bandqf.notNil and: { ~bandqf != 0 } });
+}, { ~bandf.notNil and: { ~bandf != 0 } });
 
 ~dirt.addModule('crush',
 	{ |dirtEvent|

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -95,7 +95,7 @@ live coding them requires that you have your SuperDirt instance in an environmen
 
 	SynthDef("dirt_crush" ++ numChannels, { |out, crush = 4|
 		var signal = In.ar(out, numChannels);
-		signal = signal.round(0.5 ** crush);
+		signal = signal.round(0.5 ** (crush-1));
 		ReplaceOut.ar(out, signal)
 	}, [\ir, \ir]).add;
 


### PR DESCRIPTION
SuperDirt internally uses “~cutgroup” but the Tidal keyword by default
is “cut”, so I added a translation. Similarly, SuperDirt uses “bandqf”
whereas the Tidal parameter is “bandf”. Finally, I made a change to
crush to match expected quantization to the specified number of bits.

I can separate these out into different pull requests if desired, but they're
all so small it didn't seem worth it.
