### PR TITLE
dirt-event: fix fade in and out

### DIFF
--- a/classes/DirtEvent.sc
+++ b/classes/DirtEvent.sc
@@ -109,7 +109,8 @@ DirtEvent {
 			^this // drop it.
 		};
 
-		~fadeTime = min(orbit.fadeTime, sustain * 0.19098);
+		~fadeTime = if(~end != 1) { min(orbit.fadeTime, sustain * 0.19098) } { 0.0 };
+		~fadeInTime = if(~begin != 0) { ~fadeTime } { 0.0 };
 		~sustain = sustain - (2 * ~fadeTime);
 		~speed = speed;
 		~endSpeed = endSpeed;
@@ -140,7 +141,8 @@ DirtEvent {
 				cutGroup: ~cut.abs, // ignore negatives here!
 				sample: ~hash, // required for the cutgroup mechanism
 				sustain: ~sustain, // after sustain, free all synths and group
-				fadeTime: ~fadeTime // fade in and out
+				fadeInTime: ~fadeInTime, // fade in
+				fadeTime: ~fadeTime // fade out
 			].asOSCArgArray // append all other args
 		)
 	}

--- a/classes/DirtEvent.sc
+++ b/classes/DirtEvent.sc
@@ -111,7 +111,7 @@ DirtEvent {
 
 		~fadeTime = if(~end != 1) { min(orbit.fadeTime, sustain * 0.19098) } { 0.0 };
 		~fadeInTime = if(~begin != 0) { ~fadeTime } { 0.0 };
-		~sustain = sustain - (2 * ~fadeTime);
+		~sustain = sustain - (~fadeTime + ~fadeInTime);
 		~speed = speed;
 		~endSpeed = endSpeed;
 

--- a/classes/DirtEvent.sc
+++ b/classes/DirtEvent.sc
@@ -109,7 +109,7 @@ DirtEvent {
 			^this // drop it.
 		};
 
-		~fadeTime = if(~end != 1) { min(orbit.fadeTime, sustain * 0.19098) } { 0.0 };
+		~fadeTime = min(orbit.fadeTime, sustain * 0.19098);
 		~fadeInTime = if(~begin != 0) { ~fadeTime } { 0.0 };
 		~sustain = sustain - (~fadeTime + ~fadeInTime);
 		~speed = speed;

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -61,10 +61,10 @@ live coding them requires that you have your SuperDirt instance in an environmen
 	// the monitor does the mixing and zeroing of the busses for each sample grain
 	// so that they can all play in one bus
 
-	SynthDef("dirt_gate" ++ numChannels, { |out, in, sustain = 1, fadeTime = 0.001, amp = 1|
+	SynthDef("dirt_gate" ++ numChannels, { |out, in, sustain = 1, fadeInTime = 0.001, fadeTime = 0.001, amp = 1|
 		var signal = In.ar(in, numChannels);
 		 //  doneAction: 3: free node before, which is the group with sample player and effects
-		var env = EnvGen.ar(Env([0, 1, 1, 0], [fadeTime, sustain, fadeTime], \sin), doneAction: 3);
+		var env = EnvGen.ar(Env([0, 1, 1, 0], [fadeInTime, sustain, fadeTime], \sin), doneAction: 3);
 		signal = signal * amp * env * DirtGateCutGroup.ar(sustain, fadeTime, doneAction: 3);
 		OffsetOut.ar(out, signal);
 		ReplaceOut.ar(in, Silent.ar(numChannels)) // clears bus signal for subsequent synths


### PR DESCRIPTION
only fade in if not at the beginning of the sample
