### PR TITLE
typo fix

### DIFF
--- a/classes/DirtEvent.sc
+++ b/classes/DirtEvent.sc
@@ -53,8 +53,8 @@ DirtEvent {
 				~instrument = sound;
 				~note = ~note ? ~n;
 				~freq = ~freq.value;
-				sustainControl = ~sutain ?? { synthDesc.controlDict.at(\sustain) };
-				~unitDuration = if(sustainControl.isNil) { 1.0 } { sustainControl.defaultValue ? 1.0 }; // use definition, if defined.
+				sustainControl = synthDesc.controlDict.at(\sustain);
+				~unitDuration = ~sustain ?? { if(sustainControl.isNil) { 1.0 } { sustainControl.defaultValue ? 1.0 }}; // use definition, if defined.
 			} {
 				"no synth or sample named '%' could be found.".format(sound).postln;
 			}


### PR DESCRIPTION
SuperDirt synths should now use Tidal's `sustain` parameter.
