### PR TITLE
Do not wrap orbits by default

### DIFF
--- a/classes/SuperDirt.sc
+++ b/classes/SuperDirt.sc
@@ -221,7 +221,7 @@ SuperDirt {
 				if(wrapOrbits) {
 					DirtEvent(orbits @@ index, modules, event).play
 				} {
-					if(index < orbits.size and: { index > 0 }) {
+					if(index < orbits.size and: { index >= 0 }) {
 						DirtEvent(orbits @ index, modules, event).play
 					} {
 						"SuperDirt: No orbit at this index (%)".format(index).warn


### PR DESCRIPTION
Do not wrap orbits by default.

It may be confusing that setting an orbit higher than the number of existing ones, it wraps and influences the default one (`0`).

You can switch on the wrapping if needed: `~dirt.wrapOrbits = true`.