### PR TITLE
dirt: new panning scheme

### DIFF
--- a/classes/DirtEvent.sc
+++ b/classes/DirtEvent.sc
@@ -162,6 +162,7 @@ DirtEvent {
 
 		~amp = pow(~gain, 4) * ~amp;
 		~channel !? { ~pan = ~pan + (~channel / ~numChannels) };
+		~pan = ~pan * 2 - 1; // convert unipolar (0..1) range into bipolar one (-1...1)
 		if(~cut != 0) { cutGroup = orbit.getCutGroup(~cut) };
 
 		server.makeBundle(latency, { // use this to build a bundle


### PR DESCRIPTION
This is a new panning scheme, where in multiple input channels are
distributed (“splayed”) across multiple output channels.

The conversion unipolar -> bipolar in the `pan` parameter is now done
in sclang, which is more efficient.

This is an API change. The defaultMixingFunction is replaced by a
defaultPanningFunction, so that the full panning behaviour can be
changed if needed.