### PR TITLE
Deal with absence of file extension

### DIFF
--- a/classes/SuperDirt.sc
+++ b/classes/SuperDirt.sc
@@ -169,7 +169,7 @@ SuperDirt {
 	loadSoundFile { |path, name, appendToExisting = false|
 		var buf, fileExt;
 		if(server.serverRunning.not) { "Superdirt: server not running - cannot load sound files.".throw };
-		fileExt = path.splitext[1].toLower;
+		fileExt = (path.splitext[1] ? "").toLower;
 		if(fileExtensions.includesEqual(fileExt)) {
 			buf = Buffer.readWithInfo(server, path);
 			if(buf.isNil) {


### PR DESCRIPTION
Otherwise, a file without an extension will cause `toLower` to fail and SuperDirt startup will completely halt.