### PR TITLE
Add `mul` parameter to 2-channel case

### DIFF
--- a/classes/SuperDirtUGens.sc
+++ b/classes/SuperDirtUGens.sc
@@ -54,7 +54,7 @@ DirtPanFixed2 : UGen {
 			^Pan2.ar(signals[0], pan, mul)
 		} {
 			if(n > 2) { signals = Splay.ar(signals, spread) };
-			^signals * [1 - pan, 1 + pan].clip2
+			^Balance2.ar(signals[0], signals[1], pan, mul)
 		}
 	}
 }


### PR DESCRIPTION
The `mul` parameter was left out of the 2-channel case.   I also
switched the function from `*[1-pan, 1+pan]` to `Balance2`, which
achieves the same result but with equal power instead of linear scaling.