### PR TITLE
dirt: unpause global effects correctly

### DIFF
--- a/classes/SuperDirt.sc
+++ b/classes/SuperDirt.sc
@@ -610,16 +610,17 @@ GlobalDirtEffect {
 	}
 
 	set { |event|
-		var argsChanged;
+		var argsChanged, someArgsNotNil = false;
 		paramNames.do { |key|
 			var value = event[key];
+			value !? { someArgsNotNil = true };
 			if(state[key] != value) {
 				argsChanged = argsChanged.add(key).add(value);
 				state[key] = value;
 			}
 		};
+		if(someArgsNotNil) { synth.run };
 		if(argsChanged.notNil) {
-			synth.run;
 			synth.set(*argsChanged);
 		}
 	}


### PR DESCRIPTION
global effects also get unpaused (run again) if some parameters are
still the same.