### PR TITLE
use speed for note and freq

### DIFF
--- a/classes/SuperDirt.sc
+++ b/classes/SuperDirt.sc
@@ -494,7 +494,7 @@ DirtOrbit {
 			~n = 0; // sample number or note
 			~octave = 5;
 			~midinote = #{ ~n + (~octave * 12) };
-			~freq = #{ ~midinote.midicps };
+			~freq = #{ ~midinote.midicps * ~speed };
 			~delta = 1.0;
 
 			~latency = 0.0;


### PR DESCRIPTION
You might want to use `speed` separately from `note` in softsynths, but since there are a lot of functions in tidal that will use `speed` to control pitch (in samples) it might become annoying that this isn't the same for synths.

Feel free to disagree.