### PR TITLE
separate out ~n and ~note parameters for samples, optionally for synths

### DIFF
--- a/classes/DirtEvent.sc
+++ b/classes/DirtEvent.sc
@@ -122,7 +122,6 @@ DirtEvent {
 		~amp = pow(~gain.value, 4) * ~amp.value;
 		~channel !? { ~pan = ~pan.value + (~channel.value / ~numChannels) };
 		~pan = ~pan * 2 - 1; // convert unipolar (0..1) range into bipolar one (-1...1)
-		~note = ~note ? ~n;
 		~freq = ~freq.value;
 		~delayAmp = ~delay ? 0.0; // for clarity
 		~latency = ~latency + ~lag.value + (~offset.value * ~speed.value);

--- a/classes/DirtEvent.sc
+++ b/classes/DirtEvent.sc
@@ -65,6 +65,7 @@ DirtEvent {
 		var avgSpeed, endSpeed;
 		var useUnit;
 
+		~freq = ~freq.value;
 		unitDuration = ~unitDuration.value;
 		useUnit = unitDuration.notNil;
 
@@ -122,7 +123,6 @@ DirtEvent {
 		~amp = pow(~gain.value, 4) * ~amp.value;
 		~channel !? { ~pan = ~pan.value + (~channel.value / ~numChannels) };
 		~pan = ~pan * 2 - 1; // convert unipolar (0..1) range into bipolar one (-1...1)
-		~freq = ~freq.value;
 		~delayAmp = ~delay ? 0.0; // for clarity
 		~latency = ~latency + ~lag.value + (~offset.value * ~speed.value);
 	}

--- a/classes/DirtSoundLibrary.sc
+++ b/classes/DirtSoundLibrary.sc
@@ -80,7 +80,7 @@ DirtSoundLibrary {
 						midicmd: ~midicmd ? \noteOn,
 						control: ~control ? 0,
 						ctlNum: ~ctlNum ? 0, // this one is missing from the default values
-						chan: ~midichan.postln ? 0
+						chan: ~midichan ? 0
 					).play
 				}
 			).proto_(event.copy)

--- a/classes/DirtSoundLibrary.sc
+++ b/classes/DirtSoundLibrary.sc
@@ -248,10 +248,11 @@ DirtSoundLibrary {
 	}
 
 	makeEventForBuffer { |buffer|
+		var freqDiv = 60.midicps.reciprocal;
 		^(
 			buffer: buffer.bufnum,
 			instrument: this.instrumentForBuffer(buffer),
-			unitDuration: buffer.duration,
+			unitDuration: { buffer.duration * ~freq * freqDiv },
 			hash: buffer.identityHash
 		)
 	}

--- a/classes/DirtSoundLibrary.sc
+++ b/classes/DirtSoundLibrary.sc
@@ -235,10 +235,11 @@ DirtSoundLibrary {
 		var allEvents = this.at(name);
 		^if(allEvents.isNil) {
 			if(SynthDescLib.at(name).notNil) {
-				(instrument: name, hash: name.identityHash)
+				// use tidal's "n" as note, only for synths that have no event defined
+				(instrument: name, hash: name.identityHash, note: index)
 			} {
 				if(defaultEvent.notNil) {
-					(instrument: name, hash: name.identityHash).putAll(defaultEvent)
+					(instrument: name, hash: name.identityHash, note: index).putAll(defaultEvent)
 				}
 			}
 		} {

--- a/classes/DirtSoundLibrary.sc
+++ b/classes/DirtSoundLibrary.sc
@@ -248,11 +248,11 @@ DirtSoundLibrary {
 	}
 
 	makeEventForBuffer { |buffer|
-		var freqDiv = 60.midicps.reciprocal;
+		var baseFreq = 60.midicps;
 		^(
 			buffer: buffer.bufnum,
 			instrument: this.instrumentForBuffer(buffer),
-			unitDuration: { buffer.duration * ~freq * freqDiv },
+			unitDuration: { buffer.duration * baseFreq / ~freq },
 			hash: buffer.identityHash
 		)
 	}

--- a/classes/SuperDirt.sc
+++ b/classes/SuperDirt.sc
@@ -466,7 +466,7 @@ DirtOrbit {
 			~note = 0;
 			~octave = 5;
 			~midinote = #{ ~note + (~octave * 12) };
-			~freq = #{ ~midinote.midicps };
+			~freq = #{ ~midinote.value.midicps };
 			~delta = 1.0;
 
 			~latency = 0.0;

--- a/classes/SuperDirt.sc
+++ b/classes/SuperDirt.sc
@@ -463,8 +463,9 @@ DirtOrbit {
 			~cut = 0.0;
 			~unit = \r;
 			~n = 0; // sample number or note
+			~note = 0;
 			~octave = 5;
-			~midinote = #{ ~n + (~octave * 12) };
+			~midinote = #{ ~note + (~octave * 12) };
 			~freq = #{ ~midinote.midicps };
 			~delta = 1.0;
 

--- a/synths/core-modules.scd
+++ b/synths/core-modules.scd
@@ -42,6 +42,7 @@ this may be refacored later.
 					bufnum: ~buffer,
 					sustain: ~sustain,
 					speed: ~speed,
+					freq: ~freq,
 					endSpeed: ~endSpeed,
 					begin: ~begin,
 					end: ~end,

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -26,8 +26,6 @@ live coding them requires that you have your SuperDirt instance in an environmen
 
 			var sound, rate, phase, sawrate, numFrames;
 
-			freq.poll(0);
-
 			// playback speed
 			rate = Line.kr(speed, endSpeed, sustain) * (freq / 440);
 

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -27,7 +27,7 @@ live coding them requires that you have your SuperDirt instance in an environmen
 			var sound, rate, phase, sawrate, numFrames;
 
 			// playback speed
-			rate = Line.kr(speed, endSpeed, sustain) * (freq / 440);
+			rate = Line.kr(speed, endSpeed, sustain) * (freq / 60.midicps);
 
 			// sample phase
 			// BufSampleRate adjusts the rate if the sound file doesn't have the same rate as the soundcard

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -22,12 +22,14 @@ live coding them requires that you have your SuperDirt instance in an environmen
 
 		var name = format("dirt_sample_%_%", sampleNumChannels, numChannels);
 
-		SynthDef(name, { |out, bufnum, sustain = 1, begin=0, end=1, speed = 1, endSpeed = 1, pan = 0|
+		SynthDef(name, { |out, bufnum, sustain = 1, begin = 0, end = 1, speed = 1, endSpeed = 1, freq = 440, pan = 0|
 
 			var sound, rate, phase, sawrate, numFrames;
 
+			freq.poll(0);
+
 			// playback speed
-			rate = Line.kr(speed, endSpeed, sustain);
+			rate = Line.kr(speed, endSpeed, sustain) * (freq / 440);
 
 			// sample phase
 			// BufSampleRate adjusts the rate if the sound file doesn't have the same rate as the soundcard


### PR DESCRIPTION
The sampler now uses the reference frequency of `60.midicps` for calculating the playback rate of audio buffers. You may use `n` and `note` separately. Other synths may use `n` and `note` separately if so defined (by default, you can use `n` as  a synonym for `note` in softsynths).