### PR TITLE
get dirt samples location from Quarks

### DIFF
--- a/classes/DirtSoundLibrary.sc
+++ b/classes/DirtSoundLibrary.sc
@@ -143,7 +143,7 @@ DirtSoundLibrary {
 	loadSoundFiles { |paths, appendToExisting = false, namingFunction = (_.basename)|
 		var folderPaths, memory;
 
-		paths = paths ?? { "../../Dirt-Samples/*".resolveRelative };
+		paths = paths ?? { Quarks.quarkNameAsLocalPath("Dirt-Samples") +/+ "*" };
 		folderPaths = if(paths.isString) { paths.pathMatch } { paths.asArray };
 		folderPaths = folderPaths.select(_.endsWith(Platform.pathSeparator.asString));
 		if(folderPaths.isEmpty) {

--- a/classes/DirtSoundLibrary.sc
+++ b/classes/DirtSoundLibrary.sc
@@ -133,7 +133,7 @@ DirtSoundLibrary {
 
 
 	loadOnly { |names, path, appendToExisting = false|
-		path = path ?? { "../../Dirt-Samples/".resolveRelative };
+		path = path ?? { Quarks.quarkNameAsLocalPath("Dirt-Samples") +/+ "*" };
 		names.do { |name|
 			this.loadSoundFileFolder(path +/+ name, name, appendToExisting)
 		};


### PR DESCRIPTION
so that it still works if you SuperDirt + Dirt-Samples aren't in the same place (e.g. if you have installed a git checkout manually)