### PR TITLE
Monitor pause

### DIFF
--- a/synths/core-synths-global.scd
+++ b/synths/core-synths-global.scd
@@ -39,8 +39,6 @@ CORE SYNTHDEFS FOR DIRT
 		// or:
 		//signal = distort(signal);
 
-		// DirtPause.ar(signal, graceTime:4);
-
 		signal = signal * EnvGen.kr(Env.asr, gate, doneAction:2);
 		Out.ar(outBus, signal)
 	}, [\ir, \ir, \kr, \kr]).add;

--- a/synths/core-synths-global.scd
+++ b/synths/core-synths-global.scd
@@ -39,7 +39,7 @@ CORE SYNTHDEFS FOR DIRT
 		// or:
 		//signal = distort(signal);
 
-		DirtPause.ar(signal, graceTime:4);
+		// DirtPause.ar(signal, graceTime:4);
 
 		signal = signal * EnvGen.kr(Env.asr, gate, doneAction:2);
 		Out.ar(outBus, signal)


### PR DESCRIPTION
The DirtPause UGen in dirt_monitor was causing SuperDirt to "fall asleep" if no audio was playing, and would take a few seconds to wake up.  Since it wasn't present before 1.0-dev, I've removed it.