### PR TITLE
Add TidalFX SynthDefs

### DIFF
--- a/library/default-effects-extra.scd
+++ b/library/default-effects-extra.scd
@@ -1,0 +1,42 @@
+// Waveloss
+// Divides an audio stream into tiny segments, using the signal's
+// zero-crossings as segment boundaries, and discards a fraction of them.
+
+(
+SynthDef("waveloss" ++ ~dirt.numChannels, { |out, drop = 1|
+  var sig;
+
+  sig = In.ar(out, ~dirt.numChannels);
+  sig = WaveLoss.ar(sig, drop, outof: 100, mode: 2);
+  ReplaceOut.ar(out, sig)
+}).add;
+
+~dirt.addModule('waveloss', { |dirtEvent|
+  dirtEvent.sendSynth('waveloss' ++ ~dirt.numChannels,
+    [
+      drop: ~waveloss,
+      out: ~out
+    ]
+  )
+}, { true });
+
+// Squiz
+// "reminiscent of some weird mixture of filter, ring-modulator
+// and pitch-shifter"
+
+SynthDef("squiz" ++ ~dirt.numChannels, { |out, pitchratio = 1|
+  var sig;
+  sig = In.ar(out, ~dirt.numChannels);
+  sig = Squiz.ar(sig, pitchratio);
+  ReplaceOut.ar(out, sig)
+}).add;
+
+~dirt.addModule('squiz', { |dirtEvent|
+  dirtEvent.sendSynth('squiz' ++ ~dirt.numChannels,
+    [
+      pitchratio: ~squiz,
+      out: ~out
+    ]
+  )
+}, { true });
+)

--- a/library/default-effects-extra.scd
+++ b/library/default-effects-extra.scd
@@ -18,7 +18,7 @@ SynthDef("waveloss" ++ ~dirt.numChannels, { |out, drop = 1|
       out: ~out
     ]
   )
-}, { true });
+}, { ~waveloss.notNil });
 
 // Squiz
 // "reminiscent of some weird mixture of filter, ring-modulator
@@ -38,5 +38,5 @@ SynthDef("squiz" ++ ~dirt.numChannels, { |out, pitchratio = 1|
       out: ~out
     ]
   )
-}, { true });
+}, { ~squiz.notNil });
 )

--- a/synths/try-load-extra-synths.scd
+++ b/synths/try-load-extra-synths.scd
@@ -1,9 +1,6 @@
-
-
 if(\MembraneHexagon.asClass.isNil) {
-
 	"Dirt could not load some synths from default-synths.scd, because sc3plugins are necessary and missing.".warn
-
 } {
 	loadRelative("../library/default-synths-extra.scd");
+	loadRelative("../library/default-effects-extra.scd");
 };


### PR DESCRIPTION
Adds effect SynthDefs from [TidalFX](https://github.com/calumgunn/TidalFX):

- [Waveloss](http://doc.sccode.org/Classes/WaveLoss.html)
- [Squiz](http://doc.sccode.org/Classes/Squiz.html)

Tested locally and all working fine - but the Tidal part isn't in place yet, so evaluate this in Tidal:
```
(squiz, _) = pF "squiz" (Just 1.0)
(waveloss, _) = pF "waveloss" (Just 0.0)
```

And use like so:
```
d1 $ sound "bd cp" # waveloss 40 # squiz 4
```