### PR TITLE
dirt-library: do not confuse numChannels with buffer.numChannels

### DIFF
--- a/classes/DirtRemoteSoundFileInfo.sc
+++ b/classes/DirtRemoteSoundFileInfo.sc
@@ -32,7 +32,7 @@ DirtRemoteSoundfileInfo {
 				if(bufnum.notNil) {
 					info = info.add(key);
 					info = info.add(event[\numFrames]);
-					info = info.add(event[\numChannels]);
+					info = info.add(event[\bufNumChannels]);
 					info = info.add(bufnum);
 				};
 			};
@@ -43,9 +43,9 @@ DirtRemoteSoundfileInfo {
 	convertInfoToBuffers { |info|
 		var buffers = Array.new(512);
 		info.clump(4).do { |data|
-			var key, numFrames, numChannels, bufnum, buf;
-			# key, numFrames, numChannels, bufnum = data;
-			buf = Buffer(nil, numFrames, numChannels, bufnum);
+			var key, numFrames, bufNumChannels, bufnum, buf;
+			# key, numFrames, bufNumChannels, bufnum = data;
+			buf = Buffer(nil, numFrames, bufNumChannels, bufnum);
 			buffers = buffers.add(key.asSymbol);
 			buffers = buffers.add(buf);
 		};

--- a/classes/DirtSoundLibrary.sc
+++ b/classes/DirtSoundLibrary.sc
@@ -243,7 +243,7 @@ DirtSoundLibrary {
 			buffer: buffer.bufnum,
 			instrument: this.instrumentForBuffer(buffer),
 			numFrames: buffer.numFrames,
-			numChannels: buffer.numChannels,
+			bufNumChannels: buffer.numChannels,
 			unitDuration: { buffer.duration * baseFreq / ~freq.value },
 			hash: buffer.identityHash,
 			note: 0


### PR DESCRIPTION
This fixes #114.