### PR TITLE
time stretching of samples

### DIFF
--- a/classes/DirtEvent.sc
+++ b/classes/DirtEvent.sc
@@ -102,7 +102,7 @@ DirtEvent {
 			if(~legato.notNil) {
 				~delta * ~legato.value
 			} {
-				unitDuration = (unitDuration ? ~delta) * (~stretch ? 1);
+				unitDuration = (unitDuration ? ~delta) * (~timescale ? 1);
 				loop !? { unitDuration = unitDuration * loop.abs };
 			}
 		};

--- a/classes/DirtEvent.sc
+++ b/classes/DirtEvent.sc
@@ -102,7 +102,7 @@ DirtEvent {
 			if(~legato.notNil) {
 				~delta * ~legato.value
 			} {
-				unitDuration = unitDuration ? ~delta;
+				unitDuration = (unitDuration ? ~delta) * (~stretch ? 1);
 				loop !? { unitDuration = unitDuration * loop.abs };
 			}
 		};

--- a/classes/DirtEvent.sc
+++ b/classes/DirtEvent.sc
@@ -102,7 +102,8 @@ DirtEvent {
 			if(~legato.notNil) {
 				~delta * ~legato.value
 			} {
-				unitDuration = (unitDuration ? ~delta) * (~timescale ? 1);
+				unitDuration = unitDuration ? ~delta;
+				if (~timescale.notNil) {unitDuration = unitDuration * ~timescale };
 				loop !? { unitDuration = unitDuration * loop.abs };
 			}
 		};

--- a/classes/DirtOrbit.sc
+++ b/classes/DirtOrbit.sc
@@ -189,6 +189,7 @@ DirtOrbit {
 			~midinote = #{ ~note ? ~n + (~octave * 12) };
 			~freq = #{ ~midinote.value.midicps };
 			~delta = 1.0;
+			~stretch = 1.0;
 
 			~latency = 0.0;
 			~lag = 0.0;

--- a/classes/DirtOrbit.sc
+++ b/classes/DirtOrbit.sc
@@ -189,7 +189,6 @@ DirtOrbit {
 			~midinote = #{ ~note ? ~n + (~octave * 12) };
 			~freq = #{ ~midinote.value.midicps };
 			~delta = 1.0;
-			~timescale = 1.0;
 
 			~latency = 0.0;
 			~lag = 0.0;

--- a/classes/DirtOrbit.sc
+++ b/classes/DirtOrbit.sc
@@ -189,7 +189,7 @@ DirtOrbit {
 			~midinote = #{ ~note ? ~n + (~octave * 12) };
 			~freq = #{ ~midinote.value.midicps };
 			~delta = 1.0;
-			~stretch = 1.0;
+			~timescale = 1.0;
 
 			~latency = 0.0;
 			~lag = 0.0;

--- a/classes/DirtSoundLibrary.sc
+++ b/classes/DirtSoundLibrary.sc
@@ -242,6 +242,7 @@ DirtSoundLibrary {
 		^(
 			buffer: buffer.bufnum,
 			instrument: this.instrumentForBuffer(buffer),
+			stretchInstrument: this.stretchInstrumentForBuffer(buffer),
 			bufNumFrames: buffer.numFrames,
 			bufNumChannels: buffer.numChannels,
 			unitDuration: { buffer.duration * baseFreq / ~freq.value },
@@ -252,6 +253,10 @@ DirtSoundLibrary {
 
 	instrumentForBuffer { |buffer|
 		^format("dirt_sample_%_%", buffer.numChannels, this.numChannels).asSymbol
+	}
+
+	stretchInstrumentForBuffer { |buffer|
+		^format("dirt_stretchsample_%_%", buffer.numChannels, this.numChannels).asSymbol
 	}
 
 	openFolder { |name, index = 0|
@@ -273,7 +278,8 @@ DirtSoundLibrary {
 		numChannels = n;
 		bufferEvents = bufferEvents.collect { |list|
 			list.do { |event|
-				event[\instrument] = this.instrumentForBuffer(event[\buffer])
+				event[\instrument] = this.instrumentForBuffer(event[\buffer]);
+				event[\stretchInstrument] = this.stretchInstrumentForBuffer(event[\buffer]);
 			}
 		}
 	}

--- a/hacks/looper.scd
+++ b/hacks/looper.scd
@@ -28,8 +28,9 @@ d1 $ silence
 -- play recorded loop 3 (bufnamePrefix++counter)
 d5 $ sound "fooloop3" # gain "0.7"
 
--- reset buffers.
-once $ sound "fooloopReset"
+-- reset buffers. But do only one time (d1 $ silence),
+-- since d1 $ once $ sound "fooloopReset" does not work at my installation (1.4.3)
+d1 $ sound "fooloopReset"
 
 */
 (

--- a/synths/core-modules.scd
+++ b/synths/core-modules.scd
@@ -63,7 +63,6 @@ this may be refacored later.
 						end: ~end,
 						loop: ~loop,
 						pan: ~pan,
-						timescale: ~timescale,
 						out: ~out
 					])
 				}

--- a/synths/core-modules.scd
+++ b/synths/core-modules.scd
@@ -37,20 +37,36 @@ this may be refacored later.
 	{ |dirtEvent|
 		if(~diversion.value.isNil) {
 			if(~buffer.notNil) {
-				// argumets could be omitted using getMsgFunc, but for making it easier to understand, we write them out
-				dirtEvent.sendSynth(~instrument,  [
-					bufnum: ~buffer,
-					sustain: ~sustain,
-					speed: ~speed,
-					freq: ~freq,
-					endSpeed: ~endSpeed,
-					begin: ~begin,
-					end: ~end,
-					loop: ~loop,
-					pan: ~pan,
-					timescale: ~timescale,
-					out: ~out
-				])
+				if(~timescale.notNil) {
+					dirtEvent.sendSynth(~stretchInstrument, [
+						bufnum: ~buffer,
+						sustain: ~sustain,
+						speed: ~speed,
+						freq: ~freq,
+						endSpeed: ~endSpeed,
+						begin: ~begin,
+						end: ~end,
+						loop: ~loop,
+						pan: ~pan,
+						timescale: ~timescale,
+						out: ~out
+					])
+				} {
+					// argumets could be omitted using getMsgFunc, but for making it easier to understand, we write them out
+					dirtEvent.sendSynth(~instrument,  [
+						bufnum: ~buffer,
+						sustain: ~sustain,
+						speed: ~speed,
+						freq: ~freq,
+						endSpeed: ~endSpeed,
+						begin: ~begin,
+						end: ~end,
+						loop: ~loop,
+						pan: ~pan,
+						timescale: ~timescale,
+						out: ~out
+					])
+				}
 			} {
 				if(~instrument.isNil) {
 					"module 'sound': instrument not found: %".format(~sound).postln

--- a/synths/core-modules.scd
+++ b/synths/core-modules.scd
@@ -48,7 +48,7 @@ this may be refacored later.
 					end: ~end,
 					loop: ~loop,
 					pan: ~pan,
-					stretch: ~stretch,
+					timescale: ~timescale,
 					out: ~out
 				])
 			} {

--- a/synths/core-modules.scd
+++ b/synths/core-modules.scd
@@ -48,6 +48,7 @@ this may be refacored later.
 					end: ~end,
 					loop: ~loop,
 					pan: ~pan,
+					stretch: ~stretch,
 					out: ~out
 				])
 			} {

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -21,6 +21,40 @@ live coding them requires that you have your SuperDirt instance in an environmen
 
 		var name = format("dirt_sample_%_%", sampleNumChannels, numChannels);
 
+		SynthDef(name, { |out, bufnum, sustain = 1, begin = 0, end = 1, speed = 1, endSpeed = 1, freq = 440, pan = 0|
+
+			var sound, rate, phase, sawrate, numFrames;
+
+			// playback speed
+			rate = Line.kr(speed, endSpeed, sustain) * (freq / 60.midicps);
+
+			// sample phase
+			// BufSampleRate adjusts the rate if the sound file doesn't have the same rate as the soundcard
+			//phase =  Sweep.ar(1, rate * BufSampleRate.ir(bufnum)) + (BufFrames.ir(bufnum) * begin);
+
+			numFrames = BufFrames.ir(bufnum);
+			sawrate = rate * BufSampleRate.ir(bufnum) / (absdif(begin, end) * numFrames);
+			phase = (speed.sign * LFSaw.ar(sawrate, 1)).range(begin,end) * numFrames;
+
+			sound = BufRd.ar(
+				numChannels: sampleNumChannels,
+				bufnum: bufnum,
+				phase: phase,
+				loop: 0,
+				interpolation: 4 // cubic interpolation
+			);
+
+			sound = DirtPan.ar(sound, numChannels, pan);
+
+			Out.ar(out, sound)
+		}, [\ir, \ir, \ir, \ir, \ir, \ir, \ir, \ir]).add;
+	};
+
+	// this is the time-stretching sample player
+	(1..SuperDirt.maxSampleNumChannels).do { |sampleNumChannels|
+
+		var name = format("dirt_stretchsample_%_%", sampleNumChannels, numChannels);
+
 		SynthDef(name, { |out, bufnum, sustain = 1, begin = 0, end = 1, speed = 1, endSpeed = 1, freq = 440, pan = 0, timescale = 1|
 
 			var sound, rate, phase, sawrate, numFrames, index, windowIndex, window, timescaleStep, windowSize;

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -21,9 +21,9 @@ live coding them requires that you have your SuperDirt instance in an environmen
 
 		var name = format("dirt_sample_%_%", sampleNumChannels, numChannels);
 
-		SynthDef(name, { |out, bufnum, sustain = 1, begin = 0, end = 1, speed = 1, endSpeed = 1, freq = 440, pan = 0, stretch = 1|
+		SynthDef(name, { |out, bufnum, sustain = 1, begin = 0, end = 1, speed = 1, endSpeed = 1, freq = 440, pan = 0, timescale = 1|
 
-			var sound, rate, phase, sawrate, numFrames, j0, j1, m0, m1, w0, w1, stretchStep, winsize;
+			var sound, rate, phase, sawrate, numFrames, index, windowIndex, window, timescaleStep, windowSize;
 
 			// playback speed
 			rate = Line.kr(speed, endSpeed, sustain) * (freq / 60.midicps);
@@ -33,36 +33,23 @@ live coding them requires that you have your SuperDirt instance in an environmen
 			//phase =  Sweep.ar(1, rate * BufSampleRate.ir(bufnum)) + (BufFrames.ir(bufnum) * begin);
 
 			numFrames = BufFrames.ir(bufnum);
-			winsize = numFrames * stretch / 29.0;
-			winsize = winsize.clip(1000.0*stretch, 4410.0);
-			stretchStep = winsize / stretch;
-			sawrate = rate * BufSampleRate.ir(bufnum) / (absdif(begin, end) * stretch * numFrames);
-			phase = (speed.sign * LFSaw.ar(sawrate, 1)).range(begin,end) * numFrames * stretch;
-			j1 = (phase.div(stretchStep)) * (stretchStep / stretch - stretchStep) + phase;
-			j0 = (phase.div(stretchStep) - 1.0) * (stretchStep / stretch - stretchStep) + phase;
-			m1 = phase - (phase.div(stretchStep) * stretchStep);
-			m1 = m1 / winsize;
-			m0 = phase - (phase.div(stretchStep) - 1.0 * stretchStep);
-			m0 = m0 / winsize;
-			w1 = 0.5 - (0.5 * cos(m1.clip(0.0, 1.0) * 2.0 * pi));
-			w0 = 0.5 - (0.5 * cos(m0.clip(0.0, 1.0) * 2.0 * pi));
-			w1 = exp(-0.5 * (m1 - 0.5/0.1)**2);
-			w0 = exp(-0.5 * (m0 - 0.5/0.1)**2);
+			windowSize = numFrames * timescale / 29.0;
+			windowSize = windowSize.clip(1000.0*timescale, 4410.0);
+			timescaleStep = windowSize / timescale;
+			sawrate = rate * BufSampleRate.ir(bufnum) / (absdif(begin, end) * timescale * numFrames);
+			phase = (speed.sign * LFSaw.ar(sawrate, 1)).range(begin,end) * numFrames * timescale;
+			index = (phase.div(timescaleStep) - [1.0, 0.0]) * (timescaleStep / timescale - timescaleStep) + phase;
+			windowIndex = phase - (phase.div(timescaleStep) - [1.0, 0.0] * timescaleStep);
+			window = exp(-0.5 * (windowIndex/windowSize - 0.5/0.1)**2);
 
-			sound = (w0 * BufRd.ar(
+			sound = window * BufRd.ar(
 				numChannels: sampleNumChannels,
 				bufnum: bufnum,
-				phase: j0,
+				phase: index,
 				loop: 0,
 				interpolation: 4 // cubic interpolation
-			)) + (w1 * BufRd.ar(
-				numChannels: sampleNumChannels,
-				bufnum: bufnum,
-				phase: j1,
-				loop: 0,
-				interpolation: 4 // cubic interpolation
-			));
-			sound = sound / (w0 + w1);
+			).flop;
+			sound = sound / window.sum;
 
 			sound = DirtPan.ar(sound, numChannels, pan);
 

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -68,13 +68,13 @@ live coding them requires that you have your SuperDirt instance in an environmen
 
 			numFrames = BufFrames.ir(bufnum);
 			windowSize = numFrames * timescale / 29.0;
-			windowSize = windowSize.clip(1000.0*timescale, 4410.0);
+			windowSize = windowSize.clip(1000*timescale, 4410);
 			timescaleStep = windowSize / timescale;
 			sawrate = rate * BufSampleRate.ir(bufnum) / (absdif(begin, end) * timescale * numFrames);
 			phase = (speed.sign * LFSaw.ar(sawrate, 1)).range(begin,end) * numFrames * timescale;
 			index = (phase.div(timescaleStep) - [1.0, 0.0]) * (timescaleStep / timescale - timescaleStep) + phase;
 			windowIndex = phase - (phase.div(timescaleStep) - [1.0, 0.0] * timescaleStep);
-			window = exp(-0.5 * (windowIndex/windowSize - 0.5/0.1)**2);
+			window = exp(-50 * squared(windowIndex/windowSize - 0.5));
 
 			sound = window * BufRd.ar(
 				numChannels: sampleNumChannels,

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -16,16 +16,14 @@ live coding them requires that you have your SuperDirt instance in an environmen
 {
 	var numChannels = ~dirt.numChannels;
 
-
-
 	// write variants for different sample buffer sizes
 	(1..SuperDirt.maxSampleNumChannels).do { |sampleNumChannels|
 
 		var name = format("dirt_sample_%_%", sampleNumChannels, numChannels);
 
-		SynthDef(name, { |out, bufnum, sustain = 1, begin = 0, end = 1, speed = 1, endSpeed = 1, freq = 440, pan = 0|
+		SynthDef(name, { |out, bufnum, sustain = 1, begin = 0, end = 1, speed = 1, endSpeed = 1, freq = 440, pan = 0, stretch = 1|
 
-			var sound, rate, phase, sawrate, numFrames;
+			var sound, rate, phase, sawrate, numFrames, j0, j1, m0, m1, w0, w1, stretchStep, winsize;
 
 			// playback speed
 			rate = Line.kr(speed, endSpeed, sustain) * (freq / 60.midicps);
@@ -35,21 +33,41 @@ live coding them requires that you have your SuperDirt instance in an environmen
 			//phase =  Sweep.ar(1, rate * BufSampleRate.ir(bufnum)) + (BufFrames.ir(bufnum) * begin);
 
 			numFrames = BufFrames.ir(bufnum);
-			sawrate = rate * BufSampleRate.ir(bufnum) / (absdif(begin, end) * numFrames);
-			phase = (speed.sign * LFSaw.ar(sawrate, 1)).range(begin,end) * numFrames;
+			winsize = numFrames * stretch / 29;
+			winsize = winsize * (winsize >= 1000) + ((winsize < 1000) * 1000 * stretch);
+			stretchStep = winsize / stretch;
+			sawrate = rate * BufSampleRate.ir(bufnum) / (absdif(begin, end) * stretch * numFrames);
+			phase = (speed.sign * LFSaw.ar(sawrate, 1)).range(begin,end) * numFrames * stretch;
+			j1 = (phase.div(stretchStep)) * (stretchStep / stretch - stretchStep) + phase;
+			j0 = (phase.div(stretchStep) - 1.0) * (stretchStep / stretch - stretchStep) + phase;
+			m1 = phase - (phase.div(stretchStep) * stretchStep);
+			m1 = m1 / winsize;
+			m0 = phase - (phase.div(stretchStep) - 1.0 * stretchStep);
+			m0 = m0 / winsize;
+			w1 = 0.5 - (0.5 * cos(m1.clip(0.0, 1.0) * 2.0 * pi));
+			w0 = 0.5 - (0.5 * cos(m0.clip(0.0, 1.0) * 2.0 * pi));
+			w1 = exp(-0.5 * (m1 - 0.5/0.1)**2);
+			w0 = exp(-0.5 * (m0 - 0.5/0.1)**2);
 
-			sound = BufRd.ar(
+			sound = (w0 * BufRd.ar(
 				numChannels: sampleNumChannels,
 				bufnum: bufnum,
-				phase: phase,
+				phase: j0,
 				loop: 0,
 				interpolation: 4 // cubic interpolation
-			);
+			)) + (w1 * BufRd.ar(
+				numChannels: sampleNumChannels,
+				bufnum: bufnum,
+				phase: j1,
+				loop: 0,
+				interpolation: 4 // cubic interpolation
+			));
+			sound = sound / (w0 + w1);
 
 			sound = DirtPan.ar(sound, numChannels, pan);
 
 			Out.ar(out, sound)
-		}, [\ir, \ir, \ir, \ir, \ir, \ir, \ir, \ir]).add;
+		}, [\ir, \ir, \ir, \ir, \ir, \ir, \ir, \ir, \ir, \ir]).add;
 	};
 
 	/*

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -33,8 +33,8 @@ live coding them requires that you have your SuperDirt instance in an environmen
 			//phase =  Sweep.ar(1, rate * BufSampleRate.ir(bufnum)) + (BufFrames.ir(bufnum) * begin);
 
 			numFrames = BufFrames.ir(bufnum);
-			winsize = numFrames * stretch / 29;
-			winsize = winsize * (winsize >= 1000) + ((winsize < 1000) * 1000 * stretch);
+			winsize = numFrames * stretch / 29.0;
+			winsize = winsize.clip(1000.0*stretch, 4410.0);
 			stretchStep = winsize / stretch;
 			sawrate = rate * BufSampleRate.ir(bufnum) / (absdif(begin, end) * stretch * numFrames);
 			phase = (speed.sign * LFSaw.ar(sawrate, 1)).range(begin,end) * numFrames * stretch;


### PR DESCRIPTION
This implements time-scaling for sample playback using an overlap-add (OLA) algorithm.

I tweaked the code with speed and flexibility as priorities rather than output sound quality, but for modest scaling amounts (0.8 to 1.3 or so) it usually sounds fairly good.  I'm not aware of any method that will consistently timescale transient-only sounds (most drums) in a "nice" way.

The timescaling _should_ play well with `speed`, `begin`, `end` and similar parameters, but I'm sure I haven't tested every possible combination.

Examples of usage in Tidal would be
```
timescale = pF "timescale"

d1 $ chop 4 $ s "rave" # timescale "[1 4] 2" # cps 0.5

d1 $ s "metal*4" # cps 1
 # up ("c g6 c c6" + "<c ef g c>" - 12)
 # timescale "1 3 1 2"
```