### PR TITLE
dirt-event: improve efficiency

### DIFF
--- a/classes/DirtOrbit.sc
+++ b/classes/DirtOrbit.sc
@@ -186,7 +186,7 @@ DirtOrbit {
 			~unit = \r;
 			~n = 0; // sample number or note
 			~octave = 5;
-			~midinote = #{ ~note ? ~n + (~octave * 12) };
+			~midinote = #{ ~note ?? { ~n + (~octave * 12) } };
 			~freq = #{ ~midinote.value.midicps };
 			~delta = 1.0;
 


### PR DESCRIPTION
The `??` operator inlines the function that follows it and thus avoids
the calculations if `note` is supplied directly.