### PR TITLE
use symbol as default n in event

### DIFF
--- a/classes/DirtOrbit.sc
+++ b/classes/DirtOrbit.sc
@@ -186,7 +186,7 @@ DirtOrbit {
 			~unit = \r;
 			~n = 0; // sample number or note
 			~octave = 5;
-			~midinote = #{ ~note ?? { ~n + (~octave * 12) } };
+			~midinote = #{ ~note ? ~n + (~octave * 12) };
 			~freq = #{ ~midinote.value.midicps };
 			~delta = 1.0;
 

--- a/classes/DirtOrbit.sc
+++ b/classes/DirtOrbit.sc
@@ -184,7 +184,7 @@ DirtOrbit {
 			~gain = 1.0;
 			~cut = 0.0;
 			~unit = \r;
-			~n = 0; // sample number or note
+			~n = \none; // sample number or note
 			~octave = 5;
 			~midinote = #{ ~note ? ~n + (~octave * 12) };
 			~freq = #{ ~midinote.value.midicps };

--- a/hacks/sclang-dirt.scd
+++ b/hacks/sclang-dirt.scd
@@ -8,7 +8,7 @@ SuperDirt.default = ~dirt;
 )
 
 
-
+// some hihats
 (
 Pdef(\x,
 	Pbind(
@@ -20,6 +20,24 @@ Pdef(\x,
 		\room, Pseq([0, 0, 0.4], inf)
 	)
 ).play
+)
+
+// take any, not five
+(
+var names = ~dirt.soundLibrary.bufferEvents.keys;
+var clumps = names.asArray.scramble.curdle(0.1);
+Pdef(\x,
+	Pbind(
+		\type, \dirt,
+		\s, Pn(Plazy { var n = clumps.choose; Pfuncn({ n.choose }, 64) }),
+		\n, Pwhite(0, 20, inf),
+		\speed, Pbrown(1, 1.2, 0.01),
+		\legato, 2,
+		\dur, 0.125 / 4 * Pseq([1, 1/2, 1, 2, 2, 1/2], inf),
+		\room, Pseq([0, 0, 0.4], inf)
+	)
+);
+Ppar([Pdef(\x), Pdef(\x)]).play
 )
 
 


### PR DESCRIPTION
Because Symbols are transparent to math operations (this fact is used
in sclang a lot) we can use a symbol as a default for sample number and
thereby know if any frequency related parameter (note, midinote, or
freq) was explicitly set. This helps in midi event to detect whether a
note on is intended or not.

This changes two behaviors:
- so far, one could omit note and just play with octaves. Now we have
to specify note to do this.
- now, the default value for frequency in synth events is taken from
the SynthDef (this is arguably an improvement) and doesn’t override it
with the default from the event.