### PR TITLE
Listen to any netaddr

### DIFF
--- a/classes/SuperDirt.sc
+++ b/classes/SuperDirt.sc
@@ -203,12 +203,12 @@ SuperDirt {
 			"Please note: SC3.6 listens to any sender.".warn;
 			senderAddr = nil;
 		} {
-      if (argSenderAddr.ip == "0.0.0.0") {
-        senderAddr = nil;
-      } {
-        senderAddr = argSenderAddr;
-      };
-    };
+			if (argSenderAddr.ip == "0.0.0.0") {
+                       		senderAddr = nil;
+			} {
+				senderAddr = argSenderAddr;
+			};
+		};
 
 		port = argPort;
 

--- a/classes/SuperDirt.sc
+++ b/classes/SuperDirt.sc
@@ -203,8 +203,12 @@ SuperDirt {
 			"Please note: SC3.6 listens to any sender.".warn;
 			senderAddr = nil;
 		} {
-			senderAddr = argSenderAddr
-		};
+      if (argSenderAddr.ip == "0.0.0.0") {
+        senderAddr = nil;
+      } {
+        senderAddr = argSenderAddr;
+      };
+    };
 
 		port = argPort;
 

--- a/classes/SuperDirt.sc
+++ b/classes/SuperDirt.sc
@@ -204,7 +204,7 @@ SuperDirt {
 			senderAddr = nil;
 		} {
 			if (argSenderAddr.ip == "0.0.0.0") {
-                       		senderAddr = nil;
+				senderAddr = nil;
 			} {
 				senderAddr = argSenderAddr;
 			};


### PR DESCRIPTION
I need SuperDirt to listen to any remote connection for a project I am working on involving multiple users. In https://github.com/tidalcycles/Tidal/issues/263 @yaxu mentions setting 0.0.0.0 as the NetAddr. This pull request implements that functionality for me.