### PR TITLE
Fixed small pitch shifting bug in SynthDef and add a parameter

### DIFF
--- a/synths/core-modules.scd
+++ b/synths/core-modules.scd
@@ -148,6 +148,7 @@ this may be refacored later.
 		dirtEvent.sendSynth('dirt_pitch_shift' ++ ~numChannels,
 			[
 				psrate: ~psrate,
+				disp: ~disp,
 				sustain: ~sustain,
 				out: ~out
 		])

--- a/synths/core-modules.scd
+++ b/synths/core-modules.scd
@@ -148,7 +148,7 @@ this may be refacored later.
 		dirtEvent.sendSynth('dirt_pitch_shift' ++ ~numChannels,
 			[
 				psrate: ~psrate,
-				disp: ~disp,
+				psdisp: ~psdisp,
 				sustain: ~sustain,
 				out: ~out
 		])

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -226,10 +226,10 @@ live coding them requires that you have your SuperDirt instance in an environmen
 		ReplaceOut.ar(out, signal);
 	}, [\ir, \ir, \ir, \ir, \ir]).add;
 
-	SynthDef("dirt_pitch_shift" ++ numChannels, { |out, psratio = 1, sustain = 1|
+	SynthDef("dirt_pitch_shift" ++ numChannels, { |out, psrate = 1, sustain = 1, disp = 0|
 		var signal = In.ar(out, numChannels);
 		var windowSize = sustain.linlin(0.01, 0.3, 0.01, 0.18);
-		signal = PitchShift.ar(signal, windowSize:windowSize, pitchRatio:psratio, pitchDispersion:0, timeDispersion:0);
+		signal = PitchShift.ar(signal, windowSize:windowSize, pitchRatio:psrate, pitchDispersion:0, timeDispersion:disp);
 		ReplaceOut.ar(out, signal)
 	}, [\ir, \ir, \ir]).add;
 

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -226,10 +226,10 @@ live coding them requires that you have your SuperDirt instance in an environmen
 		ReplaceOut.ar(out, signal);
 	}, [\ir, \ir, \ir, \ir, \ir]).add;
 
-	SynthDef("dirt_pitch_shift" ++ numChannels, { |out, psrate = 1, sustain = 1, disp = 0|
+	SynthDef("dirt_pitch_shift" ++ numChannels, { |out, psrate = 1, sustain = 1, psdisp = 0|
 		var signal = In.ar(out, numChannels);
 		var windowSize = sustain.linlin(0.01, 0.3, 0.01, 0.18);
-		signal = PitchShift.ar(signal, windowSize:windowSize, pitchRatio:psrate, pitchDispersion:0, timeDispersion:disp);
+		signal = PitchShift.ar(signal, windowSize:windowSize, pitchRatio:psrate, pitchDispersion:0, timeDispersion:psdisp);
 		ReplaceOut.ar(out, signal)
 	}, [\ir, \ir, \ir]).add;
 


### PR DESCRIPTION
I have seen that there is a "dirt_pitch_shift" module in core_synths. Unfortunately it does not work as intended, because the pitch shift parameter "pitchRatio" in core_synths is called ``psratio`` and in core_modules ``psrate``. 
I fixed this typo (now it is called `psrate` everywhere) and was able to use it successfully on the tidal side.

I also added the timeDispersion parameter for PitchShift and named it `disp`.