### PR TITLE
Topic/make last event accessible

### DIFF
--- a/classes/SuperDirt.sc
+++ b/classes/SuperDirt.sc
@@ -268,9 +268,9 @@ SuperDirt {
 						"SuperDirt: event falls out of existing orbits, index (%)".format(index).warn
 					};
 
-				  lastEvent.putAll(event);
-					
-          DirtEvent(orbits @@ index, modules, event).play
+					lastEvent.putAll(event);
+
+					DirtEvent(orbits @@ index, modules, event).play
 				}
 
 			}, '/play2', senderAddr, recvPort: port).fix

--- a/classes/SuperDirt.sc
+++ b/classes/SuperDirt.sc
@@ -13,6 +13,7 @@ SuperDirt {
 
 	var <numChannels, <server;
 	var <soundLibrary, <vowels;
+	var <lastEvent;
 	var <>orbits;
 	var <>modules;
 	var <>audioRoutingBusses;
@@ -29,6 +30,7 @@ SuperDirt {
 	init {
 		soundLibrary = DirtSoundLibrary(server, numChannels);
 		modules = [];
+		lastEvent = ();
 		this.loadSynthDefs;
 		this.initVowels(\counterTenor);
 		this.initRoutingBusses;
@@ -215,6 +217,7 @@ SuperDirt {
 			OSCFunc({ |msg, time, tidalAddr|
 				var latency = time - Main.elapsedTime;
 				var event = (), orbit, index;
+
 				if(latency > maxLatency) {
 					"The scheduling delay is too long. Your networks clocks may not be in sync".warn;
 					latency = 0.2;
@@ -228,6 +231,8 @@ SuperDirt {
 				if(warnOutOfOrbit and: { index >= orbits.size } or: { index < 0 }) {
 						"SuperDirt: event falls out of existing orbits, index (%)".format(index).warn
 				};
+
+				lastEvent.putAll(event);
 
 				DirtEvent(orbits @@ index, modules, event).play
 


### PR DESCRIPTION
I added a new attribute to the SuperDirt class to access the last event received from TidalCycles.

To ask the question whether this is a good idea, I would like to briefly explain what I have in mind:
The idea is to use a `playAll` function to play all samples in a sample bank in parallel. This is interesting if you add live buffers with addBuffer and want to play them immediately back (e.g. for live looping to simulate an overdub mode), without changing the code. 

In TidalCycles it could look like this (if playAll = false then you only hear the results from `n`):

```
d1 $ playAll "<t f>" # n "<0 1 2 3>"  # s "loop" 
   # cutoff (slow 8 $ (sine * 3000) + 300)
```

To this PR belongs the PR in the TidalCycles repository, because the function `pB` is missing to create the necessary pattern function `playAll = pB "playAll"` (see also: https://github.com/tidalcycles/Tidal/pull/727)

My SuperCollider code for achieving such a behaviour looks like this:
```
(
~playAll = 0;

~dirt.addModule('playAll', {
	if (~playAll != 0, {	
		~dirt.soundLibrary.buffers[~s].size.do({ 
			arg item; 
			var event = ();
			event.putAll((\type: \dirt, \dirt: ~dirt ), ~dirt.lastEvent);
			
			event.removeAt(\playAll);
			
			if (item != ~n, {
				event[\n] = item;
				event.play;
			});	
		});
	})
}, {~playAll.notNil});
)
```

Something like `(type:\dirt, dirt: ~dirt, s: \loop, n: 1).play;` is unfortunately not useful here because it does not apply any effects to the event. 