### PR TITLE
dirt-synth: move gain and overgain to synth

### DIFF
--- a/classes/DirtEvent.sc
+++ b/classes/DirtEvent.sc
@@ -117,7 +117,6 @@ DirtEvent {
 	}
 
 	finaliseParameters {
-		~amp = pow(~gain.value.min(2) + ~overgain.value, 4) * ~amp.value;
 		~channel !? { ~pan = ~pan.value + (~channel.value / ~numChannels) };
 		~pan = ~pan * 2 - 1; // convert unipolar (0..1) range into bipolar one (-1...1)
 		~delayAmp = ~delay ? 0.0; // for clarity

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -108,16 +108,17 @@ live coding them requires that you have your SuperDirt instance in an environmen
 	// the monitor does the mixing and zeroing of the busses for each sample grain
 	// so that they can all play in one bus
 
-	SynthDef("dirt_gate" ++ numChannels, { |out, in, sustain = 1, fadeInTime = 0.001, fadeTime = 0.001, amp = 1|
+	SynthDef("dirt_gate" ++ numChannels, { |out, in, sustain = 1, fadeInTime = 0.001, fadeTime = 0.001, amp = 1, gain = 1, overgain = 0|
 		var signal = In.ar(in, numChannels);
 		 //  doneAction: 14: free surrounding group and all nodes
 		var env = EnvGen.ar(Env([0, 1, 1, 0], [fadeInTime, sustain, fadeTime], \sin), doneAction: 14);
+		amp = amp * pow(gain.min(2) + overgain, 4);
 		signal = signal * env * amp * DirtGateCutGroup.ar(fadeTime, doneAction: 14);
 		// this takes the signal and offsets it so it matches precisely onto the sample
 		// as scheduled within one block (a synth is always started on the block bondary)
 		OffsetOut.ar(out, signal);
 		ReplaceOut.ar(in, Silent.ar(numChannels)) // clears bus signal for subsequent synths
-	}, [\ir, \ir, \ir, \ir, \ir, \kr]).add; // amp can be modulated
+	}, [\ir, \ir, \ir, \ir, \ir, \kr, \ir, \ir]).add; // amp can be modulated, gain and overgain can't
 
 
 	/*


### PR DESCRIPTION
This will allow a continuous modulation of `amp` with bus mappings.

It is a bit more expensive, but I have tried to minimise by making `gain` and `overgain` unmodulatable.