### PR TITLE
Improve error handling when loading samples

### DIFF
--- a/classes/DirtSoundLibrary.sc
+++ b/classes/DirtSoundLibrary.sc
@@ -195,12 +195,13 @@ DirtSoundLibrary {
 	loadSoundFilePaths { |filePaths, name, appendToExisting = false|
 
 		filePaths.do { |filepath|
-			try { |erreur|
+			try {
 				var buf = this.readSoundFile(filepath);
 				if(buf.notNil) {
 					this.addBuffer(name, buf, appendToExisting);
 					appendToExisting = true; // append all others
 				};
+			} { |erreur|
 				if(erreur.isException) { erreur.reportError };
 			}
 		}

--- a/classes/DirtSoundLibrary.sc
+++ b/classes/DirtSoundLibrary.sc
@@ -202,7 +202,7 @@ DirtSoundLibrary {
 					appendToExisting = true; // append all others
 				};
 			} { |erreur|
-				if(erreur.isException) { erreur.reportError };
+				erreur.reportError;
 			}
 		}
 

--- a/classes/extBuffer.sc
+++ b/classes/extBuffer.sc
@@ -17,7 +17,7 @@
 			numChannels = file.numChannels;
 		});
 		failed = numFrames == 0;
-		if(failed) {
+		^if(failed) {
 			"\n".post; "File reading failed for path: '%'\n\n".format(path).warn;
 			this.free; // free buffer number
 			nil


### PR DESCRIPTION
adds a missing return and corrects a `try` call. fixes #266