### PR TITLE
dirt-global-effects: synths paused not from inside

### DIFF
--- a/classes/GlobalDirtEffect.sc
+++ b/classes/GlobalDirtEffect.sc
@@ -23,10 +23,13 @@ GlobalDirtEffect {
 
 	play { |group, outBus, dryBus, effectBus, orbitIndex|
 		this.release;
-		synth = Synth.after(group, name.asString ++ numChannels,
-			[\outBus, outBus, \dryBus, dryBus, \effectBus, effectBus, \orbitIndex, orbitIndex] ++ state.asPairs
+		synth = Synth.newPaused(name.asString ++ numChannels,
+			[\outBus, outBus, \dryBus, dryBus, \effectBus, effectBus, \orbitIndex, orbitIndex] ++ state.asPairs,
+			group,
+			\addAfter
 		)
 	}
+
 
 	release { |releaseTime = 0.2|
 		if(synth.notNil) {

--- a/classes/SuperDirtUGens.sc
+++ b/classes/SuperDirtUGens.sc
@@ -193,9 +193,9 @@ DirtGateCutGroup {
 
 DirtPause {
 
-	*ar { | signal, graceTime = 1 |
+	*ar { | signal, graceTime = 1, pauseImmediately = 0 |
 		// immediately pause when started
-		PauseSelf.kr(Impulse.kr(0));
+		PauseSelf.kr(Impulse.kr(0) * pauseImmediately);
 		// when resumed and no sound is coming in, wait a while before ending again
 		signal = signal.abs + Trig1.ar(\resumed.tr(0), graceTime);
 		DetectSilence.ar(signal, time:graceTime, doneAction:1);


### PR DESCRIPTION
start synths paused not from inside by a UGen, but from outside, by calling *newPaused. This is a workaround for a recent failure, as reported in #277.