### PR TITLE
Set DirtFreqScale default factor to 1

### DIFF
--- a/classes/SuperDirtUGens.sc
+++ b/classes/SuperDirtUGens.sc
@@ -161,7 +161,7 @@ DirtFreqScale : UGen {
 	*kr { |speed = 1, accelerate = 0, sustain = 1, speedFreq|
 		var speedTerm;
 		speed = speed.abs;
-		speedFreq = speedFreq ?? { \speedFreq.ir(0) };
+		speedFreq = speedFreq ?? { \speedFreq.ir(1) };
 		speedTerm = Line.kr(speed, speed * (accelerate + 1), sustain);
 		// linear interpolation between a factor of 1 (speedFreq = 0) and of speedTerm (speedFreq = 1)
 		^speedFreq * (speedTerm - 1) + 1


### PR DESCRIPTION
It seems that all applications of `DirtFreqScale` in `library/default-synths-extra.scd` are without effect: the parameter `speedFreq` is not passed, and it's default value is 0, effectively deactivating frequency scaling.

As `DirtFreqScale` is used nowhere else, I propose to change the default value of `speedFreq` to 1.

Per #247, this should recover the old behavior of `accelerate`, fixing #254.