### PR TITLE
Use more generic vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ SuperCollider implementation of the Dirt sampler, originally designed
 for the [TidalCycles](https://github.com/tidalcycles/tidal)
 environment. SuperDirt is a general purpose framework for playing
 samples and synths, controllable over the Open Sound Control protocol,
-and locally from the SuperCollider language.
+and locally from the SuperCollider language. SuperDirt is also
+used by [Sardine](https://sardine.raphaelforment.fr), a live coding
+environment for Python 3.10+. 
 
 (C) 2015-2023 Julian Rohrhuber, Alex McLean and contributors
 

--- a/classes/SuperDirt.sc
+++ b/classes/SuperDirt.sc
@@ -339,7 +339,7 @@ SuperDirt {
 
 
 
-		"SuperDirt: listening to Tidal on port %".format(port).postln;
+		"SuperDirt: listening on port %".format(port).postln;
 	}
 
 	closeNetworkConnection {


### PR DESCRIPTION
This commit is introducing two very small changes to SuperDirt:
- a modification in the `README.md` file to indicate that Sardine also uses it.
- a modification in `SuperDirt.sc` to make the vocabulary more generic. Instead of `Listening to Tidal on port`, it will say `Listening on port`.

SuperDirt is a generic tool for SuperCollider and I suppose that my project is not the only one that piggybacks on the top of it nowadays. It would be nice to reflect that in the repository not to lock the interest of many others that would benefit from using it as well.