### PR TITLE
finally update tidal parameter syntax

### DIFF
--- a/classes/SuperDirt.sc
+++ b/classes/SuperDirt.sc
@@ -381,7 +381,7 @@ SuperDirt {
 	}
 
 	*tidalParameterString { |keys|
-		^keys.collect { |x| format("(%, %_p) = pF \"%\" (Nothing)", x, x, x) }.join("\n    ");
+		^keys.collect { |x| format("% = pF \"%\"", x, x, x) }.join("\n    ");
 	}
 
 	*predefinedSynthParameters {


### PR DESCRIPTION
```supercollider
SuperDirt.postTidalParameters([\default, \imp])
```
now gives:

```haskell
-- | parameters for the SynthDefs: default, imp
let begin = pF "begin"
    end = pF "end"
    freq = pF "freq"
    span = pF "span"
    speed = pF "speed"
```