### PR TITLE
Fix Lazy Loading

### DIFF
--- a/classes/extBuffer.sc
+++ b/classes/extBuffer.sc
@@ -27,7 +27,9 @@
 				this.allocRead(path, startFrame, numFrames, completionMessage: { |b|
 					onComplete.value(b)
 				});
-			} { this; }
+			} { 
+				this 
+			}
 		}
 	}
 

--- a/classes/extBuffer.sc
+++ b/classes/extBuffer.sc
@@ -27,8 +27,7 @@
 				this.allocRead(path, startFrame, numFrames, completionMessage: { |b|
 					onComplete.value(b)
 				});
-
-			}
+			} { this; }
 		}
 	}
 


### PR DESCRIPTION
Fixes #290 

This was SO hard to catch...

Basically lazy loading wouldn't work properly because the custom `readWithInfo` method added to `Buffer` wasn't explicitly returning the buffer itself when `onlyHeader` (which is set according to `doNotReadYet`) was set to true. It was returning `nil`, which would result on the buffer not being added to the `buffers` `IdentityDictionary`.

```supercollider
readWithInfo { |startFrame = 0, argNumFrames = -1, onlyHeader = false, onComplete|
		...
		^if(failed) {
			...
		} {
			if(onlyHeader.not) {
				if(argNumFrames > 0) { numFrames = argNumFrames };
				this.allocRead(path, startFrame, numFrames, completionMessage: { |b|
					onComplete.value(b)
				});
			} { this; } // this wasn't here before
		}
	}
```

Tested on my Windows 10 machine.