### PR TITLE
Change visibility of synth variable in GlobalDirtEffect to public

### DIFF
--- a/classes/GlobalDirtEffect.sc
+++ b/classes/GlobalDirtEffect.sc
@@ -15,7 +15,7 @@ GlobalDirtEffect {
 
 	var <>name, <>paramNames, <>numChannels, <state;
 	var <>alwaysRun = false;
-	var <>synth, defName;
+	var <synth, defName;
 
 	*new { |name, paramNames, numChannels|
 		^super.newCopyArgs(name, paramNames, numChannels, ())

--- a/classes/GlobalDirtEffect.sc
+++ b/classes/GlobalDirtEffect.sc
@@ -15,7 +15,7 @@ GlobalDirtEffect {
 
 	var <>name, <>paramNames, <>numChannels, <state;
 	var <>alwaysRun = false;
-	var synth, defName;
+	var <>synth, defName;
 
 	*new { |name, paramNames, numChannels|
 		^super.newCopyArgs(name, paramNames, numChannels, ())


### PR DESCRIPTION
To use the equalizer `EQui` in the SuperDirtMixer, it's needed to access the `synth` variable of the `GlobalDirtEffect` from outside. This helps to exchange data between the synth and the ui view. I assume this was never needed before, but it should not harm anything. 