### PR TITLE
sum channels to avoid premature pause

### DIFF
--- a/classes/SuperDirtUGens.sc
+++ b/classes/SuperDirtUGens.sc
@@ -190,7 +190,7 @@ DirtPause {
 		// immediately pause when started
 		PauseSelf.kr(Impulse.kr(0) * pauseImmediately);
 		// when resumed and no sound is coming in, wait a while before ending again
-		signal = signal.abs + Trig1.ar(\resumed.tr(0), graceTime);
+		signal = signal.abs.sum + Trig1.ar(\resumed.tr(0), graceTime);
 		DetectSilence.ar(signal, time:graceTime, doneAction:1);
 	}
 

--- a/classes/SuperDirtUGens.sc
+++ b/classes/SuperDirtUGens.sc
@@ -190,7 +190,7 @@ DirtPause {
 		// immediately pause when started
 		PauseSelf.kr(Impulse.kr(0) * pauseImmediately);
 		// when resumed and no sound is coming in, wait a while before ending again
-		signal = signal.abs.sum + Trig1.ar(\resumed.tr(0), graceTime);
+		signal = signal.abs.asArray.sum + Trig1.ar(\resumed.tr(0), graceTime);
 		DetectSilence.ar(signal, time:graceTime, doneAction:1);
 	}
 


### PR DESCRIPTION
summing the sound channels (after rectification) makes sure that there's only a single DetectSilence and that no channel can pause the node prematurely.

this is a fix for a subtle bug in DirtPause. fixing it shouldn't affect sound except in some very rare corner cases. and then one would want the fix applied anyways i guess.

issue demonstrated here using rms but same problem can be found in all places where DirtPause is used. e.g. reverbs stopping early.

```supercollider
SuperDirt.start;
~d1 = ~dirt.orbits[0];
~dirt.startSendRMS;

//with default graceTime 4 the following should finish around 9
//i.e. dirt_rms node pauses itself and stop sending messages
(
var start= Main.elapsedTime;
OSCdef(\rms, {|msg, time| (time-start).postln}, "/rms");
~d1.((sound: 'tutorial2', dur: 5, pan: 0.5));
)


//same code panned hard right.
//note: it will finish early - around 8!
(
var start= Main.elapsedTime;
OSCdef(\rms, {|msg, time| (time-start).postln}, "/rms");
~d1.((sound: 'tutorial2', dur: 5, pan: 1));
)

the silent left channel stopped dirt_rms node sending 1sec early.
with the proposed fix the two examples both hold the full duration.

```