### PR TITLE
sound library banks: add an underscore between name and bank, like in strudel.

### DIFF
--- a/classes/DirtEvent.sc
+++ b/classes/DirtEvent.sc
@@ -10,8 +10,7 @@ DirtEvent {
 	play {
 		event.parent = orbit.defaultParentEvent;
 		event.use {
-			// s and n stand for synth/sample and note/number
-			~s ?? { this.splitName };
+			this.splitName;
 			// unless orbit wide diversion returns something, we proceed
 			~diversion.(this) ?? {
 				if(~s != \) { // backslash stands for do nothing
@@ -34,14 +33,19 @@ DirtEvent {
 		orbit.server.makeBundle(~latency, func)
 	}
 
+	// s and n stand for synth/sample and note/number
 	splitName {
-		var s, n;
-		#s, n = ~sound.asString.split($:);
-		if(~bank.notNil) {
-			s = format("%_%", ~bank, s)
+		var sound, note;
+		if(~s.isNil) {
+			#sound, note = ~sound.asString.split($:);
+		} {
+			sound = ~s;
 		};
-		~s = s.asSymbol;
-		~n = if(n.notNil) { n.asFloat } { 0.0 };
+		if(~bank.notNil) {
+			sound = format("%_%", ~bank, sound)
+		};
+		~s = sound.asSymbol;
+		~n = if(note.notNil) { note.asFloat } { 0.0 };
 	}
 
 	mergeSoundEvent {

--- a/classes/DirtEvent.sc
+++ b/classes/DirtEvent.sc
@@ -37,7 +37,9 @@ DirtEvent {
 	splitName {
 		var s, n;
 		#s, n = ~sound.asString.split($:);
-		if(~bank.notNil) { s = ~bank ++ s };
+		if(~bank.notNil) {
+			s = format("%_%", ~bank, s)
+		};
 		~s = s.asSymbol;
 		~n = if(n.notNil) { n.asFloat } { 0.0 };
 	}

--- a/classes/DirtEvent.sc
+++ b/classes/DirtEvent.sc
@@ -45,7 +45,7 @@ DirtEvent {
 			sound = format("%_%", ~bank, sound)
 		};
 		~s = sound.asSymbol;
-		~n = if(note.notNil) { note.asFloat } { 0.0 };
+		~n = if(note.notNil) { note.asFloat } { ~n };
 	}
 
 	mergeSoundEvent {

--- a/classes/DirtSoundLibrary.sc
+++ b/classes/DirtSoundLibrary.sc
@@ -147,9 +147,10 @@ DirtSoundLibrary {
 		};
 	}
 
-	// a bank is defined simply by a naming convention
 	loadSoundFilesToBank { |paths, appendToExisting = false, bankName|
-		this.loadSoundFiles(paths, appendToExisting, { |path| bankName ++ "_" ++ path.basename })
+		var form = "%_%";
+		var namingFunc = if(bankName.isNil) { Error("to load into a bank, you have to give a bank name").throw };
+		this.loadSoundFiles(paths, appendToExisting, { |path| format(form, bankName, path.basename) })
 	}
 
 	loadSoundFiles { |paths, appendToExisting = false, namingFunction = (_.basename)| // paths are folderPaths

--- a/classes/DirtSoundLibrary.sc
+++ b/classes/DirtSoundLibrary.sc
@@ -147,10 +147,11 @@ DirtSoundLibrary {
 		};
 	}
 
-	loadSoundFilesToBank { |paths, appendToExisting = false, bankName|
+	loadSoundFilesToBank { |paths, appendToExisting = false, bankName, namingFunction|
 		var form = "%_%";
-		var namingFunc = if(bankName.isNil) { Error("to load into a bank, you have to give a bank name").throw };
-		this.loadSoundFiles(paths, appendToExisting, { |path| format(form, bankName, path.basename) })
+		if(bankName.isNil) { Error("to load into a bank, you have to give a bank name").throw };
+		namingFunc = namingFunc ?? { { |path| format(form, bankName, path.basename) } };
+		this.loadSoundFiles(paths, appendToExisting, namingFunc)
 	}
 
 	loadSoundFiles { |paths, appendToExisting = false, namingFunction = (_.basename)| // paths are folderPaths

--- a/classes/DirtSoundLibrary.sc
+++ b/classes/DirtSoundLibrary.sc
@@ -150,8 +150,8 @@ DirtSoundLibrary {
 	loadSoundFilesToBank { |paths, appendToExisting = false, bankName, namingFunction|
 		var form = "%_%";
 		if(bankName.isNil) { Error("to load into a bank, you have to give a bank name").throw };
-		namingFunc = namingFunc ?? { { |path| format(form, bankName, path.basename) } };
-		this.loadSoundFiles(paths, appendToExisting, namingFunc)
+		namingFunction = namingFunction ?? { { |path| format(form, bankName, path.basename) } };
+		this.loadSoundFiles(paths, appendToExisting, namingFunction)
 	}
 
 	loadSoundFiles { |paths, appendToExisting = false, namingFunction = (_.basename)| // paths are folderPaths

--- a/classes/DirtSoundLibrary.sc
+++ b/classes/DirtSoundLibrary.sc
@@ -147,6 +147,11 @@ DirtSoundLibrary {
 		};
 	}
 
+	// a bank is defined simply by a naming convention
+	loadSoundFilesToBank { |paths, appendToExisting = false, bankName|
+		this.loadSoundFiles(paths, appendToExisting, { |path| bankName ++ "_" ++ path.basename })
+	}
+
 	loadSoundFiles { |paths, appendToExisting = false, namingFunction = (_.basename)| // paths are folderPaths
 		var folderPaths, memory;
 

--- a/classes/SuperDirt.sc
+++ b/classes/SuperDirt.sc
@@ -127,12 +127,16 @@ SuperDirt {
 		soundLibrary.loadOnly(names, path, appendToExisting )
 	}
 
-	loadSoundFileFolder { |folderPath, name, appendToExisting = false, sortFiles = true|
-		soundLibrary.loadSoundFileFolder(folderPath, name, appendToExisting, sortFiles)
-	}
-
 	loadSoundFiles { |paths, appendToExisting = false, namingFunction|
 		soundLibrary.loadSoundFiles(paths, appendToExisting = false, namingFunction)
+	}
+
+	loadSoundFilesToBank { |paths, appendToExisting = false, bankName|
+		soundLibrary.loadSoundFilesToBank(paths, appendToExisting = false, bankName)
+	}
+
+	loadSoundFileFolder { |folderPath, name, appendToExisting = false, sortFiles = true|
+		soundLibrary.loadSoundFileFolder(folderPath, name, appendToExisting, sortFiles)
 	}
 
 	loadSoundFile { |path, name, appendToExisting = false|


### PR DESCRIPTION
As discussed here: #231
It may break code, but since the feature was unknown, and easy to fix, it should be good.

I've added a convenience method, you can now write: 
```supercollider
~dirt.loadSoundFilesToBank(bankName: "fufu");
```

Then in tidal:
```haskell
s "bd sd rd" # bank "fufu"
```

or synonymously:

```haskell
s "fufu_bd fufu_sd fufu_rd" 
```
