### PR TITLE
WIP: Add global resonant body effect (needs MKPlugins)

### DIFF
--- a/classes/DirtOrbit.sc
+++ b/classes/DirtOrbit.sc
@@ -61,6 +61,7 @@ DirtOrbit {
 			GlobalDirtEffect(\dirt_delay, [\delaytime, \delayfeedback, \delaySend, \delayAmp, \lock, \cps]),
 			GlobalDirtEffect(\dirt_reverb, [\size, \room, \dry]),
 			GlobalDirtEffect(\dirt_leslie, [\leslie, \lrate, \lsize]),
+			GlobalDirtEffect(\dirt_res, [\res, \resd, \ress, \resn]),
 			GlobalDirtEffect(\dirt_rms, [\rmsReplyRate, \rmsPeakLag]).alwaysRun_(true).active_(false),
 			GlobalDirtEffect(\dirt_monitor, [\limitertype]).alwaysRun_(true),
 		]

--- a/classes/DirtOrbit.sc
+++ b/classes/DirtOrbit.sc
@@ -61,7 +61,7 @@ DirtOrbit {
 			GlobalDirtEffect(\dirt_delay, [\delaytime, \delayfeedback, \delaySend, \delayAmp, \lock, \cps]),
 			GlobalDirtEffect(\dirt_reverb, [\size, \room, \dry]),
 			GlobalDirtEffect(\dirt_leslie, [\leslie, \lrate, \lsize]),
-			GlobalDirtEffect(\dirt_res, [\res, \resd, \ress, \resn]),
+			GlobalDirtEffect(\dirt_res, [\res, \resd, \ress, \resn, \resb]),
 			GlobalDirtEffect(\dirt_rms, [\rmsReplyRate, \rmsPeakLag]).alwaysRun_(true).active_(false),
 			GlobalDirtEffect(\dirt_monitor, [\limitertype]).alwaysRun_(true),
 		]

--- a/synths/core-synths-global.scd
+++ b/synths/core-synths-global.scd
@@ -123,6 +123,26 @@ CORE SYNTHDEFS FOR DIRT
 		}, [\ir, \ir]).add;
 	};
 
+	if(\Resonator.asClass.notNil) {
+		// Needs MKPlugins, see https://github.com/madskjeldgaard/portedplugins
+		SynthDef("dirt_res" ++ numChannels, { |dryBus, effectBus, gate = 1, res = 0, resn = 0, resd = 0.5, ress=0.2, lock = 0|
+			var in, signal;
+			in = In.ar(dryBus, numChannels);
+			ReplaceOut.ar(dryBus, in * (1 - res));
+
+			signal = in.asArray.collect { |sig|
+				Resonator.ar(sig, freq: (resn + 60).midicps, position: 0.001, resolution: 12, structure: 0.2, brightness: 0.03, damping: resd);
+			};
+
+			// in = if(numChannels > 2) { in.clump(2).sum } { in.dup };
+
+			// signal = Resonator.ar(in, freq: (resn + 60).midicps, position: 0.001, resolution: 12, structure: 0.2, brightness: 0.03, damping: resd);
+			signal = signal * EnvGen.kr(Env.asr, gate, doneAction:2) * res;
+
+			DirtPause.ar(signal, graceTime:4);
+			Out.ar(effectBus, signal);
+		}, [\ir, \ir]).add;
+	} {};
 
 	// thanks to Jost Muxfeld and James McCartney
 	// note that "size" is not room size, just the feed level into the room

--- a/synths/core-synths-global.scd
+++ b/synths/core-synths-global.scd
@@ -125,13 +125,13 @@ CORE SYNTHDEFS FOR DIRT
 
 	if(\Resonator.asClass.notNil) {
 		// Needs MKPlugins, see https://github.com/madskjeldgaard/portedplugins
-		SynthDef("dirt_res" ++ numChannels, { |dryBus, effectBus, gate = 1, res = 0, resn = 0, resd = 0.5, ress=0.2, lock = 0|
+		SynthDef("dirt_res" ++ numChannels, { |dryBus, effectBus, gate = 1, res = 0, resn = 0, resd = 0.5, ress=0.2, resb = 0.03, lock = 0|
 			var in, signal;
 			in = In.ar(dryBus, numChannels);
 			ReplaceOut.ar(dryBus, in * (1 - res));
 
 			signal = in.asArray.collect { |sig|
-				Resonator.ar(sig, freq: (resn + 60).midicps, position: 0.001, resolution: 12, structure: 0.2, brightness: 0.03, damping: resd);
+				Resonator.ar(sig, freq: resn.midicps, position: 0.001, resolution: 12, structure: ress, brightness: resb, damping: resd);
 			};
 
 			// in = if(numChannels > 2) { in.clump(2).sum } { in.dup };


### PR DESCRIPTION
I wanted this after working with a mridangam player B C Manjunath and percussionist on a drum kit Matt Davies. Manjunath's mridangam was tuned to D, and Matt tuned his drums to the same where possible, adding a resonator triggered by a piezo so that his kick drum also was tuned to D. It sounded great so wanted this for superdirt too. It's a global (i.e. orbit-bound) effect wrapping the resonator from [MKPlugins](https://github.com/madskjeldgaard/portedplugins), originally from [mutable instruments](https://github.com/pichenettes/eurorack).